### PR TITLE
Update the _beforeTokenTransfer function

### DIFF
--- a/contracts/PatikaBears.sol
+++ b/contracts/PatikaBears.sol
@@ -101,9 +101,10 @@ contract PatikaBears is ERC721, ERC721Enumerable, Pausable, Ownable {
   function _beforeTokenTransfer(
     address from,
     address to,
-    uint256 tokenId
+    uint256 tokenId,
+    uint256 batchId
   ) internal override(ERC721, ERC721Enumerable) whenNotPaused {
-    super._beforeTokenTransfer(from, to, tokenId);
+    super._beforeTokenTransfer(from, to, tokenId, batchId);
   }
 
   // ONLY OWNER FUNCTIONS


### PR DESCRIPTION
Openzeppelin updated the _beforeTokenTransfer function to take the batchId as the 4th parameter. So, I have update it. Please review and merge it.